### PR TITLE
DPI awareness at runtime

### DIFF
--- a/Source/Modules/High/FlappyClone/FlappyClone.cpp
+++ b/Source/Modules/High/FlappyClone/FlappyClone.cpp
@@ -472,7 +472,7 @@ namespace FlappyClone
         ecs.system<Position, Scale, Color>("FlappyClone::UpdateObstacles")
             .kind(flecs::OnUpdate)
             .with<Obstacle>().up(flecs::ChildOf)
-            .each([](flecs::iter& it, size_t i, Position& position, Scale& scale, Color const& color)
+            .each([](flecs::iter& it, size_t i, Position& position, Scale const& scale, Color const& color)
                 {
                     GameContext const* pGameCtx = it.world().has<GameContext>() ? it.world().get<GameContext>() : nullptr;
 
@@ -533,7 +533,7 @@ namespace FlappyClone
         // - Handles player inputs 
         ecs.system<Player, Position, Scale, Color, Velocity, FontRendering::FontText>("FlappyClone::UpdatePlayer")
             .kind(flecs::OnUpdate)
-            .each([](flecs::iter& it, size_t i, Player& player, Position& position, Scale& scale, Color const& color, Velocity& vel, FontRendering::FontText& fontText)
+            .each([](flecs::iter& it, size_t i, Player& player, Position const& position, Scale const& scale, Color const& color, Velocity& vel, FontRendering::FontText& fontText)
                 {
                     ASSERTMSG(i == 0, "More than 1 player not supported.");
                     
@@ -692,7 +692,7 @@ namespace FlappyClone
         // - Records GPU cmds
         ecs.system<Engine::Canvas, Window::SDLWindow>("FlappyClone::Draw")
             .kind(flecs::OnStore)
-            .each([](flecs::iter& it, size_t i, Engine::Canvas& canvas, Window::SDLWindow& sdlWin)
+            .each([](flecs::iter& it, size_t i, Engine::Canvas const& canvas, Window::SDLWindow const& sdlWin)
                 {
                     ASSERTMSG(i == 0, "Drawing to more than one window not implemented.");
 

--- a/Source/Modules/High/HelloTriangle/HelloTriangle.cpp
+++ b/Source/Modules/High/HelloTriangle/HelloTriangle.cpp
@@ -287,7 +287,7 @@ namespace HelloTriangle
 
         ecs.system<Engine::Canvas, Window::SDLWindow>("HelloTriangle::Draw")
             .kind(flecs::OnStore)
-            .each([](flecs::iter& it, size_t i, Engine::Canvas& canvas, Window::SDLWindow& sdlWin)
+            .each([](flecs::iter& it, size_t i, Engine::Canvas const& canvas, Window::SDLWindow const& sdlWin)
                 {
                     ASSERTMSG(i == 0, "Drawing to more than one window not implemented.");
 

--- a/Source/Modules/Low/Window.cpp
+++ b/Source/Modules/Low/Window.cpp
@@ -201,7 +201,7 @@ namespace Window
 
         auto present = ecs.system<Window::SDLWindow>("Present")
             .kind(Engine::GetCustomPhaseEntity(ecs, Engine::PRESENT))
-            .each([](flecs::iter& it, size_t i, Window::SDLWindow& sdlWin)
+            .each([](flecs::iter& it, size_t i, Window::SDLWindow const& sdlWin)
                 {
                     ASSERTMSG(i == 0, "More than one window not implemented.");
 

--- a/Source/Modules/Medium/FontRendering.cpp
+++ b/Source/Modules/Medium/FontRendering.cpp
@@ -41,7 +41,7 @@ namespace FontRendering
         
         auto fontSysInitializer = ecs.system<Engine::Canvas, Window::SDLWindow>("Init Font System")
             .kind(flecs::OnLoad)
-            .each([](flecs::iter& it, size_t i, Engine::Canvas& canvas, Window::SDLWindow& sdlWin)
+            .each([](flecs::iter& it, size_t i, Engine::Canvas const& canvas, Window::SDLWindow const& sdlWin)
                 {
                     ASSERTMSG(i == 0, "Only 1 window is supported.");
 
@@ -131,7 +131,7 @@ namespace FontRendering
        
         auto fontSysResizer = ecs.system<Engine::Canvas, Window::SDLWindow>("Font System Resizer")
             .kind(flecs::OnLoad)
-            .each([](flecs::iter& it, size_t i, Engine::Canvas& canvas, Window::SDLWindow const& sdlWin)
+            .each([](flecs::iter& it, size_t i, Engine::Canvas const& canvas, Window::SDLWindow const& sdlWin)
                 {
                     ASSERTMSG(i == 0, "Only 1 window is supported.");
 
@@ -177,7 +177,7 @@ namespace FontRendering
 
         auto fontRenderer = ecs.system<Engine::Canvas, Window::SDLWindow>("Font Renderer")
             .kind(Engine::GetCustomPhaseEntity(ecs, Engine::FONTS_RENDER))
-            .each([](flecs::iter& it, size_t i, Engine::Canvas& canvas, Window::SDLWindow& sdlWin)
+            .each([](flecs::iter& it, size_t i, Engine::Canvas const& canvas, Window::SDLWindow const& sdlWin)
                 {
                     ASSERTMSG(i == 0, "Drawing to more than one window not implemented.");
 

--- a/Source/Modules/Medium/FontRendering.h
+++ b/Source/Modules/Medium/FontRendering.h
@@ -7,7 +7,7 @@
 // Implemented features:
 // - [X] Using different fonts (and sizes)
 // - [X] Address non 1x DPI scale at init time (including fonts)
-// - [ ] Address DPI changes at runtime (OS settings change and per monitor)
+// - [X] Address DPI changes at runtime (OS settings change and per monitor)
 
 namespace FontRendering
 {

--- a/Source/Modules/Medium/Imgui/UI.cpp
+++ b/Source/Modules/Medium/Imgui/UI.cpp
@@ -47,7 +47,7 @@ namespace UI
         
         ecs.system<Engine::Canvas, Window::SDLWindow>("UI Initializer")
             .kind(flecs::OnLoad)
-            .each([](flecs::iter& it, size_t i, Engine::Canvas& canvas, Window::SDLWindow const& sdlWin)
+            .each([](flecs::iter& it, size_t i, Engine::Canvas const& canvas, Window::SDLWindow const& sdlWin)
                 {
                     ASSERTMSG(i == 0, "Only 1 window is supported.");
 
@@ -143,7 +143,7 @@ namespace UI
 
         ecs.system<Engine::Canvas, Window::SDLWindow>("UI Draw")
             .kind(Engine::GetCustomPhaseEntity(ecs, Engine::UI_RENDER))
-            .each([](flecs::iter& it, size_t i, Engine::Canvas& canvas, Window::SDLWindow& sdlWin)
+            .each([](flecs::iter& it, size_t i, Engine::Canvas const& canvas, Window::SDLWindow const& sdlWin)
                 {
                     if (!it.world().has<Context>())
                         return;

--- a/Source/Modules/Medium/Imgui/UI.cpp
+++ b/Source/Modules/Medium/Imgui/UI.cpp
@@ -242,6 +242,27 @@ namespace UI
                         // All loaded, we can clear the fontsToLoad set
                         pContext->fontsToLoad.clear();
                     }
+
+                    // Handle content scale changes
+                    float contentScale = 1.f;
+
+                    SDL_DisplayID const dispId = SDL_GetDisplayForWindow(sdlWin.pWindow);
+                    if (dispId == 0)
+                    {
+                        LOGF(eERROR, "SDL_GetDisplayForWindow() failed.");
+                    }
+                    else
+                    {
+                        contentScale = SDL_GetDisplayContentScale(dispId);
+                    }
+
+                    if (pContext->contentScale != contentScale)
+                    {
+                        // Update imgui style scales
+                        ImGui::GetStyle().ScaleAllSizes(contentScale / pContext->contentScale);
+
+                        pContext->contentScale = contentScale;
+                    }
                 }
             );
     }

--- a/Source/Modules/Medium/Imgui/UI.cpp
+++ b/Source/Modules/Medium/Imgui/UI.cpp
@@ -102,6 +102,9 @@ namespace UI
                     // Build the atlas texture
                     ImGui_TheForge_BuildFontAtlas(pRHI->pGfxQueue);
 
+                    // Ensure style is setup for content scale
+                    ImGui::GetStyle().ScaleAllSizes(pContext->contentScale);
+
                     pContext->isInitialized = true;
 
                     // Ensure we notify modifications for following systems in the same phase that'll use the context

--- a/Source/Modules/Medium/Imgui/UI.cpp
+++ b/Source/Modules/Medium/Imgui/UI.cpp
@@ -47,7 +47,7 @@ namespace UI
         
         ecs.system<Engine::Canvas, Window::SDLWindow>("UI Initializer")
             .kind(flecs::OnLoad)
-            .each([](flecs::iter& it, size_t i, Engine::Canvas& canvas, Window::SDLWindow& sdlWin)
+            .each([](flecs::iter& it, size_t i, Engine::Canvas& canvas, Window::SDLWindow const& sdlWin)
                 {
                     ASSERTMSG(i == 0, "Only 1 window is supported.");
 
@@ -128,7 +128,7 @@ namespace UI
 
         ecs.system<UI>("UI Updater")
             .kind(flecs::PostUpdate) // Want to run UI updates after OnUpdate phase is done
-            .each([](flecs::iter& it, size_t i, UI& ui)
+            .each([](flecs::iter& it, size_t i, UI const& ui)
                 {
                     if (!it.world().has<Context>())
                         return;

--- a/Source/Modules/Medium/Imgui/UI.h
+++ b/Source/Modules/Medium/Imgui/UI.h
@@ -35,7 +35,7 @@ namespace UI
 	bool WantsCaptureInputs(flecs::world& ecs);
 
 	// This function will always return a valid ImFont* if the UI is currently initialized.
-	// A nullptr represents the fallback font (which should always be valid for usage).
+	// A nullptr can be returned if UI is not initialized or if the default font failed to load for some reason.  In that case, don't call on ImGui::Push/PopFont()
 	// If the specified font was not yet loaded, it will be loaded at a deferred time and the default fallback font will be returned.
 	ImFont* GetOrAddFont(flecs::world& ecs, FontRendering::eAvailableFonts const font, float const size);
 }


### PR DESCRIPTION
- Fixed some minor things with previous imgui impl
- Added dpi awareness at runtime for FontRendering and UI modules
- Proper const correctness for all flecs systems in the codebase
  
Tested on Windows by modifying monitor content scale in OS settings and by dragging a window across different scaled monitors' boundary.  
  
![dpi_awareness](https://github.com/user-attachments/assets/edb77bab-587e-4953-86fb-6cb39fe7575e)
