### PR TITLE
ImGui - Scale default font for content scale

### DIFF
--- a/Source/Modules/Medium/Imgui/UI.cpp
+++ b/Source/Modules/Medium/Imgui/UI.cpp
@@ -91,7 +91,7 @@ namespace UI
                     }
 
                     // Load default font
-                    unsigned int actualFontSize = DEFAULT_IMGUI_FONT_SIZE * pContext->contentScale; // ImGui guidelines recommends getting the floor
+                    unsigned int const actualFontSize = DEFAULT_IMGUI_FONT_SIZE * pContext->contentScale; // ImGui guidelines recommends getting the floor
                     ImFontConfig fontConfig = ImFontConfig();
                     fontConfig.SizePixels = static_cast<float>(actualFontSize);
                     ImFont* pDefaultFont = io.Fonts->AddFontDefault(&fontConfig);
@@ -215,7 +215,7 @@ namespace UI
                         pContext->contentScale = contentScale;
 
                         // Lets ensure we load up the default font for the new content scale
-                        unsigned int actualFontSize = DEFAULT_IMGUI_FONT_SIZE * pContext->contentScale;
+                        unsigned int const actualFontSize = DEFAULT_IMGUI_FONT_SIZE * pContext->contentScale;
                         if (pContext->loadedFonts.find({ DEFAULT_IMGUI_FONT_ID , actualFontSize }) == pContext->loadedFonts.end())
                             pContext->fontsToLoad.insert({ DEFAULT_IMGUI_FONT_ID , actualFontSize });
                     }
@@ -290,7 +290,7 @@ namespace UI
                     // If content scale changed, we need to reset the default font for the target content scale
                     if (contentScaleChanged)
                     {
-                        unsigned int actualFontSize = DEFAULT_IMGUI_FONT_SIZE * pContext->contentScale;
+                        unsigned int const actualFontSize = DEFAULT_IMGUI_FONT_SIZE * pContext->contentScale;
                         if (pContext->loadedFonts.find({ DEFAULT_IMGUI_FONT_ID , actualFontSize }) != pContext->loadedFonts.end())
                         {
                             ImGui::GetIO().FontDefault = pContext->loadedFonts.at({DEFAULT_IMGUI_FONT_ID , actualFontSize});


### PR DESCRIPTION
Missing from previous DPI awareness PR, the default imgui font was not being scaled appropriately.  
When UI module detects a content scale change, it will ensure that the default scaled imgui font is added and set as default.